### PR TITLE
Übersichtstypen erweitert um auch Tilgungspläne zu ermöglichen

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,43 @@ Dies ist ein einfaches Beispiel, wie eine Haushaltsrechnung in der API aussehen 
         "titel": "Einnahmen",
         "zeilen": [
           {
-            "label": "Unselbst\u00e4ndiges Nettoeinkommen",
-            "wert": 4000.00
+            "zellen": [
+              {
+                "typ": "LABEL",
+                "label": "Unselbst\u00e4ndiges Nettoeinkommen"
+              },
+              {
+                "typ": "EURO",
+                "euro": 4000.00
+              }
+            ]
           },
           {
-            "label": "Eink\u00fcnfte aus Nebent\u00e4tigkeit",
-            "wert": 200.00
+            "zellen": [
+              {
+                "typ": "LABEL",
+                "label": "Eink\u00fcnfte aus Nebent\u00e4tigkeit"
+              },
+              {
+                "typ": "EURO",
+                "euro": 200.00
+              }
+            ]
           }
         ],
         "innerBlock": {
           "zeilen": [
             {
-              "label": "Summe Einnahmen",
-              "wert": 4200.00,
+              "zellen": [
+                {
+                  "typ": "LABEL",
+                  "label": "Summe Einnahmen"
+                },
+                {
+                  "typ": "EURO",
+                  "euro": 4200.00
+                }
+              ],
               "hervorgehoben": true
             }
           ],
@@ -38,19 +62,43 @@ Dies ist ein einfaches Beispiel, wie eine Haushaltsrechnung in der API aussehen 
         "titel": "Ausgaben",
         "zeilen": [
           {
-            "label": "Lebenshaltungskosten",
-            "wert": 857.81
+            "zellen": [
+              {
+                "typ": "LABEL",
+                "label": "Lebenshaltungskosten"
+              },
+              {
+                "typ": "EURO",
+                "euro": 857.81
+              }
+            ]
           },
           {
-            "label": "Mietausgaben",
-            "wert": 1000.00
+            "zellen": [
+              {
+                "typ": "LABEL",
+                "label": "Mietausgaben"
+              },
+              {
+                "typ": "EURO",
+                "euro": 1000.00
+              }
+            ]
           }
         ],
         "innerBlock": {
           "zeilen": [
             {
-              "label": "Summe Ausgaben",
-              "wert": 1857.81,
+              "zellen": [
+                {
+                  "typ": "LABEL",
+                  "label": "Summe Ausgaben"
+                },
+                {
+                  "typ": "EURO",
+                  "euro": 1857.81
+                }
+              ],
               "hervorgehoben": true
             }
           ],
@@ -62,8 +110,16 @@ Dies ist ein einfaches Beispiel, wie eine Haushaltsrechnung in der API aussehen 
         "innerBlock": {
           "zeilen": [
             {
-              "label": "\u00dcberschuss",
-              "wert": 2342.19,
+              "zellen": [
+                {
+                  "typ": "LABEL",
+                  "label": "\u00dcberschuss"
+                },
+                {
+                  "typ": "EURO",
+                  "euro": 2342.19
+                }
+              ],
               "hervorgehoben": true
             }
           ],
@@ -72,4 +128,4 @@ Dies ist ein einfaches Beispiel, wie eine Haushaltsrechnung in der API aussehen 
       }
     ]
   }
-  ```
+```

--- a/swagger.yml
+++ b/swagger.yml
@@ -571,7 +571,7 @@ definitions:
         $ref: '#/definitions/euro'
       kapitalvermoegen:
         $ref: '#/definitions/euro'
-        
+
   nebentaetigkeit:
     type: object
     properties:
@@ -580,7 +580,7 @@ definitions:
       beginn:
         type: string
         format: date
-        
+
   mietUndPachteinnahmen:
     type: object
     properties:
@@ -1077,7 +1077,7 @@ definitions:
         $ref: '#/definitions/unterlageReferenz'
     required:
       - text
-  
+
   unterlageReferenz:
     type: object
     properties:
@@ -1093,7 +1093,7 @@ definitions:
     type: string
     enum:
       - ANTRAGSTELLER
-      
+
   angebotsstatus:
     type: object
     properties:
@@ -1380,13 +1380,23 @@ definitions:
     properties:
       hervorgehoben:
         type: boolean
+      zellen:
+        type: array
+        items:
+          $ref: '#/definitions/zelle'
+    required:
+      - zellen
+
+  zelle:
+    type: object
+    properties:
+      typ:
+        type: string
+        enum: [LABEL, EURO]
       label:
         type: string
-      wert:
+      euro:
         $ref: '#/definitions/euro'
-    required:
-      - label
-      - wert
 
   ###########################################
   ### Globale Typen fuer Request+Response ###


### PR DESCRIPTION
https://trello.com/c/MeH0TecV

- Übersichtstypen erweitert um auch Darstellung von Ansichten mit variabler Spaltenanzahl zu ermöglichen (angelehnt an interne Übersichten API der ME)
- Voraussetzung um später noch Tilgungspläne übermitteln zu können

