### PR TITLE
KITT-608 Angebot um Möglichkeit der Markierung als Downsell erweitert…

### DIFF
--- a/beispiele/annahme-mit-downselling.md
+++ b/beispiele/annahme-mit-downselling.md
@@ -4,7 +4,6 @@ Führt die Haushaltsrechnung zu einer Haushaltsunterdeckung, kann ein Downsellin
 Wenn ein Downselling erfolgt, muss das Angebot in der Antwort den Block 
 ```
     "alternative": {
-      "bezeichnung": "Alternative: Downsell",
       "typ": "DOWNSELL"
     }
 ```
@@ -318,7 +317,6 @@ Die Beispielantworten sind fiktiv und gekürzt, sodass die Konditionen bspw. nic
     },
     "maximalerAuszahlungsbetrag": null,
     "alternative": {
-      "bezeichnung": "Alternative: Downsell",
       "typ": "DOWNSELL"
     }
   },

--- a/beispiele/annahme-mit-downselling.md
+++ b/beispiele/annahme-mit-downselling.md
@@ -1,13 +1,18 @@
-## Annahme mit vollständigen Angaben (ein Antragsteller)
+## Annahme mit Downselling
+
+Führt die Haushaltsrechnung zu einer Haushaltsunterdeckung, kann ein Downselling erfolgen. Dazu wird entweder die Laufzeit verlängert und oder der Kreditbetrag verringert, um die monatliche Belastung zu reduzieren. 
+Wenn ein Downselling erfolgt, muss das Angebot in der Antwort den Block 
+```
+    "alternative": {
+      "bezeichnung": "Alternative: Downsell",
+      "typ": "DOWNSELL"
+    }
+```
+enthalten. Die Bezeichnung ist optional.
 
 Die aufgelisteten Beispielanfragen und -antworten dienen zum besseren Verständnis der API. 
 
 Die Beispielantworten sind fiktiv und gekürzt, sodass die Konditionen bspw. nicht mit dem Tilgungsplan übereinstimmen.   
-
-Anmerkung zum Tilgungsplan:
-- i.d.R. wird das erste Jahr monatsweise aufgelistet
-- i.d.R. werden alle weiteren Jahre jeweils zu einem einzelnen Eintrag pro Jahr aggregiert
-- die Beispielantworten enthalten lediglich die ersten beiden und den letzten Eintrag - die Dazwischenliegenden wurden entfernt  
 
 ### Request
 
@@ -104,9 +109,9 @@ Anmerkung zum Tilgungsplan:
   "finanzierungswunsch": {
     "kreditwunsch": {
       "finanzierungszweck": "MODERNISIERUNG_UND_WOHNEN",
-      "auszahlungsbetrag": 25000.0,
+      "auszahlungsbetrag": 35000.0,
       "ratenzahlungstermin": "ULTIMO",
-      "laufzeitInMonaten": 92
+      "laufzeitInMonaten": 72
     },
     "versicherungsWunsch": [],
     "konto": {
@@ -226,25 +231,23 @@ Anmerkung zum Tilgungsplan:
     "meldungen": [
       {
         "kategorie": "ANPASSUNG",
-        "text": "Der Provisionswunsch wurde angepasst.",
-        "code": null
+        "text": "Der Provisionswunsch wurde angepasst."
       },
       {
         "kategorie": "ANPASSUNG",
-        "text": "Die Laufzeit wurde angepasst.",
-        "code": null
+        "text": "Der Auszahlungsbetrag wurde angepasst."
+      },
+      {
+        "kategorie": "ANPASSUNG",
+        "text": "Die Laufzeit wurde angepasst."
       }
     ],
     "unterlagen": [
       {
-        "code": null,
-        "text": "Unterzeichneter Baufinanzierungsvertrag",
-        "referenz": null
+        "text": "Unterzeichneter Baufinanzierungsvertrag"
       },
       {
-        "code": null,
-        "text": "Unterzeichneter Darlehensantrag",
-        "referenz": null
+        "text": "Unterzeichneter Darlehensantrag"
       }
     ],
     "bonitaetscheck": {
@@ -313,117 +316,11 @@ Anmerkung zum Tilgungsplan:
         }
       ]
     },
-    "tilgungsplanBausparvertragMitVorausdarlehen": {
-      "sparphase": {
-        "eintraege": [
-          {
-            "jahr": 2019,
-            "monat": 10,
-            "gesamtrate": 150.0,
-            "vorausdarlehenSollzinsen": -60.0,
-            "vorausdarlehenSaldo": -25000.0,
-            "bausparvertragEinzahlungen": 100.0,
-            "bausparvertragGuthabenzinsen": 0.0,
-            "bausparvertragGebuehren": -400.0,
-            "bausparvertragTilgung": null,
-            "bausparvertragSollzinsen": null,
-            "bausparvertragSaldo": -250.0
-          },
-          {
-            "jahr": 2019,
-            "monat": 11,
-            "gesamtrate": 150.0,
-            "vorausdarlehenSollzinsen": -60.0,
-            "vorausdarlehenSaldo": -25000.0,
-            "bausparvertragEinzahlungen": 100.0,
-            "bausparvertragGuthabenzinsen": 0.0,
-            "bausparvertragGebuehren": 0.0,
-            "bausparvertragTilgung": null,
-            "bausparvertragSollzinsen": null,
-            "bausparvertragSaldo": -150.0
-          },
-          {
-            "jahr": 2027,
-            "monat": null,
-            "gesamtrate": 1000.0,
-            "vorausdarlehenSollzinsen": -450.9,
-            "vorausdarlehenSaldo": null,
-            "bausparvertragEinzahlungen": 650.0,
-            "bausparvertragGuthabenzinsen": 10.0,
-            "bausparvertragGebuehren": -10.0,
-            "bausparvertragTilgung": null,
-            "bausparvertragSollzinsen": null,
-            "bausparvertragSaldo": null
-          }
-        ],
-        "werteBeiPhasenEnde": {
-          "gesamtrate": 15000.0,
-          "vorausdarlehenSollzinsen": -5000.0,
-          "vorausdarlehenSaldo": -25000.0,
-          "bausparvertragEinzahlungen": 10000.0,
-          "bausparvertragGuthabenzinsen": 70.0,
-          "bausparvertragGebuehren": -500.0,
-          "bausparvertragTilgung": null,
-          "bausparvertragSollzinsen": null,
-          "bausparvertragSaldo": 10000.0
-        }
-      },
-      "darlehensphase": {
-        "eintraege": [
-          {
-            "jahr": 2027,
-            "monat": 7,
-            "gesamtrate": 0.0,
-            "vorausdarlehenSollzinsen": null,
-            "vorausdarlehenSaldo": null,
-            "bausparvertragEinzahlungen": null,
-            "bausparvertragGuthabenzinsen": null,
-            "bausparvertragGebuehren": null,
-            "bausparvertragTilgung": 0.0,
-            "bausparvertragSollzinsen": 0.0,
-            "bausparvertragSaldo": -14000.0
-          },
-          {
-            "jahr": 2027,
-            "monat": 8,
-            "gesamtrate": 150.0,
-            "vorausdarlehenSollzinsen": null,
-            "vorausdarlehenSaldo": null,
-            "bausparvertragEinzahlungen": null,
-            "bausparvertragGuthabenzinsen": null,
-            "bausparvertragGebuehren": null,
-            "bausparvertragTilgung": 150.0,
-            "bausparvertragSollzinsen": -30.0,
-            "bausparvertragSaldo": -15000.0
-          },
-          {
-            "jahr": 2035,
-            "monat": null,
-            "gesamtrate": 500.0,
-            "vorausdarlehenSollzinsen": null,
-            "vorausdarlehenSaldo": null,
-            "bausparvertragEinzahlungen": null,
-            "bausparvertragGuthabenzinsen": null,
-            "bausparvertragGebuehren": null,
-            "bausparvertragTilgung": 500.0,
-            "bausparvertragSollzinsen": -5.0,
-            "bausparvertragSaldo": null
-          }
-        ],
-        "werteBeiPhasenEnde": {
-          "gesamtrate": 16466.44,
-          "vorausdarlehenSollzinsen": null,
-          "vorausdarlehenSaldo": null,
-          "bausparvertragEinzahlungen": null,
-          "bausparvertragGuthabenzinsen": null,
-          "bausparvertragGebuehren": null,
-          "bausparvertragTilgung": 14989.63,
-          "bausparvertragSollzinsen": -1476.81,
-          "bausparvertragSaldo": 0.0
-        }
-      }
-    },
-    "maximalerAuszahlungsbetrag": null
+    "maximalerAuszahlungsbetrag": null,
+    "alternative": {
+      "bezeichnung": "Alternative: Downsell",
+      "typ": "DOWNSELL"
+    }
   },
   "dokumente": [
     {

--- a/beispiele/annahme-mit-vollstaendigen-angaben-ein-antragsteller.md
+++ b/beispiele/annahme-mit-vollstaendigen-angaben-ein-antragsteller.md
@@ -423,7 +423,11 @@ Anmerkung zum Tilgungsplan:
         }
       }
     },
-    "maximalerAuszahlungsbetrag": null
+    "maximalerAuszahlungsbetrag": null,
+    "alternative": {
+      "bezeichnung": "Alternative: Downsell",
+      "typ": "DOWNSELL"
+    }
   },
   "dokumente": [
     {

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 10.0.0
+  version: 10.0.1
   title: MarketEngine-API für Bausparkassen
 basePath: /v1
 schemes:

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 10.0.1
+  version: 10.1.0
   title: MarketEngine-API für Bausparkassen
 basePath: /v1
 schemes:

--- a/swagger.yml
+++ b/swagger.yml
@@ -1067,7 +1067,7 @@ definitions:
       maximalerAuszahlungsbetrag:
         $ref: '#/definitions/euro'
       alternative:
-        description: Pflichtfeld wenn sich das Angebot um ein Downsell handelt, also entweder die Laufzeit verlängert und oder der Kreditbetrag verringert wurde. In diesem Falle ist zusätzlich mindestens eine Anpassungsmeldung zu liefern.
+        description: Pflichtfeld wenn sich das Angebot um ein Downsell-Angebot handelt. Ein Downsell liegt vor, wenn die gwwünschte Laufzeit verlängert und oder der gewünschte Kreditbetrag verringert wird, um eine nagtive Haushaltsrechnung auszugleichen. In diesem Falle ist zusätzlich mindestens eine Anpassungsmeldung zu liefern.
         $ref: '#/definitions/angebotAlternative'
     required:
       - produktanbieter
@@ -1441,14 +1441,13 @@ definitions:
     type: object
     properties:
       bezeichnung:
-        description: "Beispiel: Alternative: Downsell"
+        description: "Bezeichnung des alternativen Angebots. Bei fehlender Angabe wird die Standard-Bezeichung `Alternative: Downsell` verwendet"
         type: string
         maxLength: 30
       typ:
         description: Aktuell wird nur DOWNSELL als Typ des alternativen Angebotes unterstützt
         $ref: '#/definitions/angebotAlternativeTyp'
     required:
-      - bezeichnung
       - typ
 
   angebotAlternativeTyp:

--- a/swagger.yml
+++ b/swagger.yml
@@ -575,7 +575,7 @@ definitions:
         $ref: '#/definitions/euro'
       kapitalvermoegen:
         $ref: '#/definitions/euro'
-        
+
   nebentaetigkeit:
     type: object
     properties:
@@ -584,7 +584,7 @@ definitions:
       beginn:
         type: string
         format: date
-        
+
   mietUndPachteinnahmen:
     type: object
     properties:
@@ -1066,6 +1066,9 @@ definitions:
         $ref: '#/definitions/tilgungsplanBausparvertragMitVorausdarlehen'
       maximalerAuszahlungsbetrag:
         $ref: '#/definitions/euro'
+      alternative:
+        description: Pflichtfeld wenn sich das Angebot um ein Downsell handelt, also entweder die Laufzeit verlängert und oder der Kreditbetrag verringert wurde. In diesem Falle ist zusätzlich mindestens eine Anpassungsmeldung zu liefern.
+        $ref: '#/definitions/angebotAlternative'
     required:
       - produktanbieter
       - produktbezeichnung
@@ -1095,7 +1098,7 @@ definitions:
         $ref: '#/definitions/unterlageReferenz'
     required:
       - text
-  
+
   unterlageReferenz:
     type: object
     properties:
@@ -1111,7 +1114,7 @@ definitions:
     type: string
     enum:
       - ANTRAGSTELLER
-      
+
   angebotsstatus:
     type: object
     properties:
@@ -1433,6 +1436,25 @@ definitions:
         $ref: '#/definitions/euro'
       bausparvertragSaldo:
         $ref: '#/definitions/euro'
+
+  angebotAlternative:
+    type: object
+    properties:
+      bezeichnung:
+        description: "Beispiel: Alternative: Downsell"
+        type: string
+        maxLength: 30
+      typ:
+        description: Aktuell wird nur DOWNSELL als Typ des alternativen Angebotes unterstützt
+        $ref: '#/definitions/angebotAlternativeTyp'
+    required:
+      - bezeichnung
+      - typ
+
+  angebotAlternativeTyp:
+    type: string
+    enum:
+      - DOWNSELL
 
   bonitaetscheck:
     type: object


### PR DESCRIPTION
Perspektivisch kann es auch Upsell-Angebote geben, daher wurde hier ein ENUM verwendet.
Max-Length verwendet, damit der Bezeichner in das Frontend Layout passt.