### PR TITLE
KITT-2989: Remove several, obsolete fields

### DIFF
--- a/beispiele/anfrage-mit-minimalen-angaben.md
+++ b/beispiele/anfrage-mit-minimalen-angaben.md
@@ -54,9 +54,7 @@ Angabe von Kreditbetrag und Laufzeit
           "leasings": [],
           "kreditkarten": [],
           "dispositionskredite": [],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -78,8 +76,7 @@ Angabe von Kreditbetrag und Laufzeit
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {}
   },

--- a/beispiele/anfrage-mit-vollstaendigen-angaben-ein-antragsteller.md
+++ b/beispiele/anfrage-mit-vollstaendigen-angaben-ein-antragsteller.md
@@ -91,9 +91,7 @@ Anmerkung zum Tilgungsplan:
           "leasings": [],
           "kreditkarten": [],
           "dispositionskredite": [],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -116,8 +114,7 @@ Anmerkung zum Tilgungsplan:
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {}
   },

--- a/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-im-gemeinsamen-haushalt.md
+++ b/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-im-gemeinsamen-haushalt.md
@@ -92,9 +92,7 @@ Anmerkung zum Tilgungsplan:
           "leasings": [],
           "kreditkarten": [],
           "dispositionskredite": [],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     },
@@ -175,9 +173,7 @@ Anmerkung zum Tilgungsplan:
           "leasings": [],
           "kreditkarten": [],
           "dispositionskredite": [],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -199,9 +195,7 @@ Anmerkung zum Tilgungsplan:
         "leasings": [],
         "kreditkarten": [],
         "dispositionskredite": [],
-        "immobiliendarlehen": [],
-        "geschaeftskredite": [],
-        "kontokorrentkredite": []
+        "immobiliendarlehen": []
       }
     },
     "kinder": []
@@ -221,8 +215,7 @@ Anmerkung zum Tilgungsplan:
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {}
   },

--- a/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-in-getrennten-haushalten.md
+++ b/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-in-getrennten-haushalten.md
@@ -91,9 +91,7 @@ Anmerkung zum Tilgungsplan:
           "leasings": [],
           "kreditkarten": [],
           "dispositionskredite": [],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     },
@@ -174,9 +172,7 @@ Anmerkung zum Tilgungsplan:
           "leasings": [],
           "kreditkarten": [],
           "dispositionskredite": [],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -198,9 +194,7 @@ Anmerkung zum Tilgungsplan:
         "leasings": [],
         "kreditkarten": [],
         "dispositionskredite": [],
-        "immobiliendarlehen": [],
-        "geschaeftskredite": [],
-        "kontokorrentkredite": []
+        "immobiliendarlehen": []
       }
     },
     "kinder": []
@@ -220,8 +214,7 @@ Anmerkung zum Tilgungsplan:
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {}
   },

--- a/beispiele/annahme-mit-downselling.md
+++ b/beispiele/annahme-mit-downselling.md
@@ -95,9 +95,7 @@ Die Beispielantworten sind fiktiv und gekürzt, sodass die Konditionen bspw. nic
           "leasings": [],
           "kreditkarten": [],
           "dispositionskredite": [],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -120,8 +118,7 @@ Die Beispielantworten sind fiktiv und gekürzt, sodass die Konditionen bspw. nic
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {}
   },

--- a/beispiele/annahme-mit-vollstaendigen-angaben-ein-antragsteller.md
+++ b/beispiele/annahme-mit-vollstaendigen-angaben-ein-antragsteller.md
@@ -91,9 +91,7 @@ Anmerkung zum Tilgungsplan:
           "leasings": [],
           "kreditkarten": [],
           "dispositionskredite": [],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -116,8 +114,7 @@ Anmerkung zum Tilgungsplan:
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {}
   },

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 10.3.0
+  version: 11.0.0
   title: MarketEngine-API für Bausparkassen
 basePath: /v1
 schemes:
@@ -582,8 +582,6 @@ definitions:
         $ref: '#/definitions/mietUndPachteinnahmen'
       sonstige:
         $ref: '#/definitions/euro'
-      kapitalvermoegen:
-        $ref: '#/definitions/euro'
 
   nebentaetigkeit:
     type: object
@@ -639,20 +637,10 @@ definitions:
   vermoegen:
     type: object
     properties:
-      rueckkaufswertLebensversicherung:
-        $ref: '#/definitions/euro'
-      bausparguthaben:
-        $ref: '#/definitions/euro'
       immobilien:
         type: array
         items:
           $ref: '#/definitions/immobilie'
-      depot:
-        $ref: '#/definitions/euro'
-      bankUndSparguthaben:
-        $ref: '#/definitions/euro'
-      sonstiges:
-        $ref: '#/definitions/euro'
 
   immobilie:
     type: object
@@ -704,14 +692,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/immobiliendarlehen'
-      geschaeftskredite:
-        type: array
-        items:
-          $ref: '#/definitions/geschaeftskredit'
-      kontokorrentkredite:
-        type: array
-        items:
-          $ref: '#/definitions/kontokorrentkredit'
 
   ratenkredit:
     type: object
@@ -802,37 +782,6 @@ definitions:
       restschuld:
         $ref: '#/definitions/euro'
 
-  geschaeftskredit:
-    type: object
-    properties:
-      id:
-        type: string
-      monatlicheRate:
-        $ref: '#/definitions/euro'
-      letzteRate:
-        $ref: '#/definitions/euro'
-      datumLetzteRate:
-        type: string
-        format: date
-      restschuld:
-        $ref: '#/definitions/euro'
-      glaeubiger:
-        type: string
-
-  kontokorrentkredit:
-    type: object
-    properties:
-      id:
-        type: string
-      verfuegungsrahmen:
-        $ref: '#/definitions/euro'
-      beanspruchterBetrag:
-        $ref: '#/definitions/euro'
-      zinssatz:
-        $ref: '#/definitions/prozent'
-      glaeubiger:
-        type: string
-
   ###
   ### Finanzierungswunsch
   ###
@@ -894,10 +843,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/abzuloesenderDispositionskredit'
-      geschaeftskredite:
-        type: array
-        items:
-          $ref: '#/definitions/abzuloesenderGeschaeftskredit'
 
   finanzierungszweck:
     description: Verwendungszweck
@@ -953,19 +898,6 @@ definitions:
     properties:
       id:
         type: string
-      konto:
-        $ref: '#/definitions/konto'
-
-  abzuloesenderGeschaeftskredit:
-    type: object
-    properties:
-      id:
-        type: string
-      datumErsteRate:
-        type: string
-        format: date
-      urspruenglicherBetrag:
-        $ref: '#/definitions/euro'
       konto:
         $ref: '#/definitions/konto'
 


### PR DESCRIPTION
Nach Abstimmung mit den Banken können folgende Felder ersatzlos entfernt werden:

- `rueckkaufswertLebensversicherung`
- `bausparguthaben`
- `depotguthaben`
- `bankUndSparguthaben`
- `sonstigesVermoegen`
- `einkuenfteAusKapitalvermoegen`
- `geschaeftskredite`
- `kontokorrentkredite`

Nach Rückfrage betrifft `geschaeftskredite` die Verbindlichkeiten, als auch die abzulösenden Verbindlichkeiten.
Im Zuge der Änderungen wird die Version auf die neue Major Version 11.0.0 erhöht.