### PR TITLE
KITT-3051: Adding new field "modernisierungsbetrag"

### DIFF
--- a/beispiele/anfrage-mit-minimalen-angaben.md
+++ b/beispiele/anfrage-mit-minimalen-angaben.md
@@ -78,7 +78,8 @@ Angabe von Kreditbetrag und Laufzeit
       "kreditkarten": [],
       "dispositionskredite": []
     },
-    "fahrzeug": {}
+    "fahrzeug": {},
+    "modernisierung": {}
   },
   "kundenbetreuer": {
     "partnerId": "ABC12",

--- a/beispiele/anfrage-mit-vollstaendigen-angaben-ein-antragsteller.md
+++ b/beispiele/anfrage-mit-vollstaendigen-angaben-ein-antragsteller.md
@@ -116,7 +116,8 @@ Anmerkung zum Tilgungsplan:
       "kreditkarten": [],
       "dispositionskredite": []
     },
-    "fahrzeug": {}
+    "fahrzeug": {},
+    "modernisierung": {}
   },
   "kundenbetreuer": {
     "partnerId": "ABC12",

--- a/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-im-gemeinsamen-haushalt.md
+++ b/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-im-gemeinsamen-haushalt.md
@@ -217,7 +217,8 @@ Anmerkung zum Tilgungsplan:
       "kreditkarten": [],
       "dispositionskredite": []
     },
-    "fahrzeug": {}
+    "fahrzeug": {},
+    "modernisierung": {}
   },
   "kundenbetreuer": {
     "partnerId": "ABC12",

--- a/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-in-getrennten-haushalten.md
+++ b/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-in-getrennten-haushalten.md
@@ -216,7 +216,8 @@ Anmerkung zum Tilgungsplan:
       "kreditkarten": [],
       "dispositionskredite": []
     },
-    "fahrzeug": {}
+    "fahrzeug": {},
+    "modernisierung": {}
   },
   "kundenbetreuer": {
     "partnerId": "ABC12",

--- a/beispiele/annahme-mit-downselling.md
+++ b/beispiele/annahme-mit-downselling.md
@@ -120,7 +120,8 @@ Die Beispielantworten sind fiktiv und gekürzt, sodass die Konditionen bspw. nic
       "kreditkarten": [],
       "dispositionskredite": []
     },
-    "fahrzeug": {}
+    "fahrzeug": {},
+    "modernisierung": {}
   },
   "kundenbetreuer": {
     "partnerId": "ABC12",

--- a/beispiele/annahme-mit-vollstaendigen-angaben-ein-antragsteller.md
+++ b/beispiele/annahme-mit-vollstaendigen-angaben-ein-antragsteller.md
@@ -116,7 +116,8 @@ Anmerkung zum Tilgungsplan:
       "kreditkarten": [],
       "dispositionskredite": []
     },
-    "fahrzeug": {}
+    "fahrzeug": {},
+    "modernisierung": {}
   },
   "kundenbetreuer": {
     "partnerId": "ABC12",

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 11.0.0
+  version: 11.1.0
   title: MarketEngine-API für Bausparkassen
 basePath: /v1
 schemes:
@@ -525,6 +525,12 @@ definitions:
       - PRIVAT
       - HAENDLER
 
+  modernisierung:
+    type: object
+    properties:
+      modernisierungsbetrag:
+        $ref: '#/definitions/euro'
+
   bonitaetsangaben:
     type: object
     properties:
@@ -801,6 +807,8 @@ definitions:
         $ref: '#/definitions/abzuloesendeVerbindlichkeiten'
       fahrzeug:
         $ref: '#/definitions/fahrzeug'
+      modernisierung:
+        $ref: '#/definitions/modernisierung'
     required:
       - kreditwunsch
 


### PR DESCRIPTION
Neues Feld "modernisierungsbetrag" für die Signal Iduna. Es wird den Wert des eigentlich benötigten Betrags für eine Modernisierung beinhalten. Das neue Feld ist analog zum bereits bestehenden in der KEX Api angelegt worden.

Die minor Version wurde wegen des neuen Felds erhöht.