### PR TITLE
#KITT-3817 add ruecklastschrift

### DIFF
--- a/beispiele/anfrage-mit-vollstaendigen-angaben-ein-antragsteller.md
+++ b/beispiele/anfrage-mit-vollstaendigen-angaben-ein-antragsteller.md
@@ -97,7 +97,10 @@ Anmerkung zum Tilgungsplan:
     }
   ],
   "gemeinsameAntragstellerangaben": {
-    "bonitaetsangaben": {}
+    "bonitaetsangaben": {},
+    "ruecklastschrift": {
+      "ruecklastschriftWithinDays": 30
+    }
   },
   "finanzierungswunsch": {
     "kreditwunsch": {

--- a/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-im-gemeinsamen-haushalt.md
+++ b/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-im-gemeinsamen-haushalt.md
@@ -198,7 +198,10 @@ Anmerkung zum Tilgungsplan:
         "immobiliendarlehen": []
       }
     },
-    "kinder": []
+    "kinder": [],
+    "ruecklastschrift": {
+      "ruecklastschriftWithinDays": 60
+    }
   },
   "finanzierungswunsch": {
     "kreditwunsch": {

--- a/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-in-getrennten-haushalten.md
+++ b/beispiele/anfrage-mit-vollstaendigen-angaben-mehrere-antragsteller-in-getrennten-haushalten.md
@@ -197,7 +197,10 @@ Anmerkung zum Tilgungsplan:
         "immobiliendarlehen": []
       }
     },
-    "kinder": []
+    "kinder": [],
+    "ruecklastschrift": {
+      "ruecklastschriftWithinDays": 90
+    }
   },
   "finanzierungswunsch": {
     "kreditwunsch": {

--- a/beispiele/annahme-mit-vollstaendigen-angaben-ein-antragsteller.md
+++ b/beispiele/annahme-mit-vollstaendigen-angaben-ein-antragsteller.md
@@ -97,7 +97,10 @@ Anmerkung zum Tilgungsplan:
     }
   ],
   "gemeinsameAntragstellerangaben": {
-    "bonitaetsangaben": {}
+    "bonitaetsangaben": {},
+    "ruecklastschrift": {
+      "ruecklastschriftWithinDays": 90
+    }
   },
   "finanzierungswunsch": {
     "kreditwunsch": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -226,6 +226,17 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/kind'
+      ruecklastschrift:
+        description: is null if there are no ruecklastschriften.
+        $ref: '#/definitions/ruecklastschrift'
+
+  ruecklastschrift:
+    type: object
+    properties:
+      ruecklastschriftWithinDays:
+        type: integer
+    required:
+      - ruecklastschriftWithinDays
 
   antragsteller:
     type: object


### PR DESCRIPTION
In Abgrenzung zur ME API würde ich hier:
- den Parameter `ruecklastschriftWithinDays` statt `daysSinceLastRuecklastschrift` nennen
- auf das `exists`-Flag verzichten und stattdessen festlegen das der Knoten null ist wenn es keine Rücklastschrift gab

https://europace.atlassian.net/browse/KITT-3817