### PR TITLE
#KITT-4458 add A2A-Konten

### DIFF
--- a/beispiele/anfrage-mit-a2a-daten.md
+++ b/beispiele/anfrage-mit-a2a-daten.md
@@ -1,0 +1,573 @@
+## Anfrage mit vollständigen Angaben (mehrere Antragsteller im gemeinsamen Haushalt)
+
+Die aufgelisteten Beispielanfragen und -antworten dienen zum besseren Verständnis der API. 
+
+Die Beispielantworten sind fiktiv und gekürzt, sodass die Konditionen bspw. nicht mit dem Tilgungsplan übereinstimmen.   
+
+Anmerkung zum Tilgungsplan:
+- i.d.R. wird das erste Jahr monatsweise aufgelistet
+- i.d.R. werden alle weiteren Jahre jeweils zu einem einzelnen Eintrag pro Jahr aggregiert
+- die Beispielantworten enthalten lediglich die ersten beiden und den letzten Eintrag - die Dazwischenliegenden wurden entfernt  
+
+### Request
+
+```json
+{
+  "antragsteller": [
+    {
+      "id": "552a2e18-b407-44ce-8af5-f6334cc64f80",
+      "haushaltspartnerId": "21794c8f-ad7c-442f-9bd5-1449951acd82",
+      "persoenlicheAngaben": {
+        "anrede": "HERR",
+        "vorname": "Beispiel Vorname",
+        "nachname": "Beispiel Nachname",
+        "geburtsdatum": "1970-01-01",
+        "geburtsort": "Berlin",
+        "staatsangehoerigkeit": "DE",
+        "familienstand": "VERHEIRATET",
+        "anzahlPersonenImHaushalt": 2
+      },
+      "derzeitigeBeschaeftigung": {
+        "beschaeftigungsverhaeltnis": "ANGESTELLT",
+        "befristet": "UNBEFRISTET",
+        "beschaeftigtSeit": "2010-01-01",
+        "beruf": "Angestellter",
+        "branche": "HANDEL",
+        "anschrift": {
+          "strasse": "Beispielstr.",
+          "hausnummer": "43",
+          "postleitzahl": "10179",
+          "ort": "Berlin",
+          "land": "DE"
+        },
+        "arbeitgebername": "Beispiel AG"
+      },
+      "vorherigeBeschaeftigung": {
+        "anschrift": {}
+      },
+      "derzeitigeWohnsituation": {
+        "wohnart": "IM_EIGENEN_HAUS",
+        "wohnhaftSeit": "2000-01-01",
+        "anschrift": {
+          "strasse": "Beispielstr.",
+          "hausnummer": "42",
+          "postleitzahl": "10179",
+          "ort": "Berlin",
+          "land": "DE"
+        }
+      },
+      "kontakt": {
+        "telefonPrivat": "030 123456",
+        "telefonGeschaeftlich": "030 123456",
+        "email": "beispiel@beispiel.de"
+      },
+      "herkunft": {
+        "aufenthaltstitel": {}
+      },
+      "kinder": [],
+      "rentenversicherung": {
+        "anschrift": {}
+      },
+      "bonitaetsangaben": {
+        "ausgaben": {},
+        "einnahmen": {
+          "monatlicheEinnahmen": {
+            "regelmaessigesUnselbstaendigesEinkommen": 3000,
+            "mietUndPachteinnahmen": {}
+          },
+          "jaehrlicheEinnahmen": {
+            "einkommenAusSelbstaendigkeit": {
+              "zuVersteuerndesEinkommen": {},
+              "einkommenssteuer": {},
+              "abschreibungen": {}
+            }
+          }
+        },
+        "vermoegen": {
+          "immobilien": []
+        },
+        "verbindlichkeiten": {
+          "ratenkredite": [],
+          "sonstigeVerbindlichkeiten": [],
+          "leasings": [],
+          "kreditkarten": [],
+          "dispositionskredite": [],
+          "immobiliendarlehen": []
+        }
+      }
+    },
+    {
+      "id": "21794c8f-ad7c-442f-9bd5-1449951acd82",
+      "haushaltspartnerId": "552a2e18-b407-44ce-8af5-f6334cc64f80",
+      "persoenlicheAngaben": {
+        "anrede": "FRAU",
+        "vorname": "Beispiel Vorname 2",
+        "nachname": "Beispiel Nachname",
+        "geburtsdatum": "1970-07-01",
+        "geburtsort": "Berlin",
+        "staatsangehoerigkeit": "DE",
+        "familienstand": "VERHEIRATET"
+      },
+      "derzeitigeBeschaeftigung": {
+        "beschaeftigungsverhaeltnis": "ANGESTELLT",
+        "befristet": "UNBEFRISTET",
+        "beschaeftigtSeit": "2010-01-01",
+        "beruf": "Angestellter",
+        "branche": "HANDEL",
+        "anschrift": {
+          "strasse": "Beispielstr",
+          "hausnummer": "43",
+          "postleitzahl": "10179",
+          "ort": "Berlin",
+          "land": "DE"
+        },
+        "arbeitgebername": "Beispiel AG"
+      },
+      "vorherigeBeschaeftigung": {
+        "anschrift": {}
+      },
+      "derzeitigeWohnsituation": {
+        "wohnart": "IM_EIGENEN_HAUS",
+        "wohnhaftSeit": "2000-01-01",
+        "anschrift": {
+          "strasse": "Beispielstr.",
+          "hausnummer": "42",
+          "postleitzahl": "10179",
+          "ort": "Berlin",
+          "land": "DE"
+        }
+      },
+      "kontakt": {
+        "telefonPrivat": "030 123456",
+        "telefonGeschaeftlich": "030 123456",
+        "email": "beispiel2@beispiel.de"
+      },
+      "herkunft": {
+        "aufenthaltstitel": {}
+      },
+      "kinder": [],
+      "rentenversicherung": {
+        "anschrift": {}
+      },
+      "bonitaetsangaben": {
+        "ausgaben": {},
+        "einnahmen": {
+          "monatlicheEinnahmen": {
+            "regelmaessigesUnselbstaendigesEinkommen": 3000,
+            "mietUndPachteinnahmen": {}
+          },
+          "jaehrlicheEinnahmen": {
+            "einkommenAusSelbstaendigkeit": {
+              "zuVersteuerndesEinkommen": {},
+              "einkommenssteuer": {},
+              "abschreibungen": {}
+            }
+          }
+        },
+        "vermoegen": {
+          "immobilien": []
+        },
+        "verbindlichkeiten": {
+          "ratenkredite": [],
+          "sonstigeVerbindlichkeiten": [],
+          "leasings": [],
+          "kreditkarten": [],
+          "dispositionskredite": [],
+          "immobiliendarlehen": []
+        }
+      }
+    }
+  ],
+  "gemeinsameAntragstellerangaben": {
+    "bonitaetsangaben": {
+      "ausgaben": {},
+      "einnahmen": {
+        "monatlicheEinnahmen": {
+          "mietUndPachteinnahmen": {}
+        }
+      },
+      "vermoegen": {
+        "immobilien": []
+      },
+      "verbindlichkeiten": {
+        "ratenkredite": [],
+        "sonstigeVerbindlichkeiten": [],
+        "leasings": [],
+        "kreditkarten": [],
+        "dispositionskredite": [],
+        "immobiliendarlehen": []
+      }
+    },
+    "kinder": [],
+    "ruecklastschrift": {
+      "ruecklastschriftWithinDays": 60
+    }
+  },
+  "finanzierungswunsch": {
+    "kreditwunsch": {
+      "finanzierungszweck": "MODERNISIERUNG_UND_WOHNEN",
+      "auszahlungsbetrag": 25000,
+      "ratenzahlungstermin": "ULTIMO",
+      "laufzeitInMonaten": 60
+    },
+    "versicherungsWunsch": [],
+    "konto": {
+      "kontoinhaberIds": []
+    },
+    "abzuloesendeVerbindlichkeiten": {
+      "ratenkredite": [],
+      "sonstigeVerbindlichkeiten": [],
+      "kreditkarten": [],
+      "dispositionskredite": []
+    },
+    "fahrzeug": {},
+    "modernisierung": {}
+  },
+  "kundenbetreuer": {
+    "partnerId": "ABC12",
+    "firmenname": "Beispiel AG",
+    "vorname": "Beispiel Vorname",
+    "nachname": "Beispiel Nachname",
+    "anschrift": {
+      "strasse": "Beispielstr.",
+      "hausnummer": "42",
+      "postleitzahl": "10179",
+      "ort": "Berlin"
+    },
+    "telefon": "030 123456",
+    "email": "beispiel@beispiel.de",
+    "iban": "DE75201207003100124444",
+    "anrede": "HERR"
+  },
+  "metadaten": {
+    "traceId": "ks-84d56ccf",
+    "vorgangsnummer": "AB1234"
+  },
+  "featureToggles": [],
+  "handelsbeziehungen": [
+    {
+      "produktanbieter": "BEISPIEL_BANK",
+      "kreditProvisionswunsch": 0.0123,
+      "vertriebsgruppe": "Beispielgruppe"
+    }
+  ],
+  "a2aKonten": [
+    {
+      "iban": "DE7510050000000000000",
+      "gemeinschaftskonto": true,
+      "antragsteller": [
+        {
+          "id": "552a2e18-b407-44ce-8af5-f6334cc64f80",
+          "hauptbankverbindung": false
+        },
+        {
+          "id": "21794c8f-ad7c-442f-9bd5-1449951acd82",
+          "hauptbankverbindung": true
+        }
+      ]
+    },
+    {
+      "iban": "DE7510050000000000001",
+      "gemeinschaftskonto": true,
+      "antragsteller": [
+        {
+          "id": "552a2e18-b407-44ce-8af5-f6334cc64f80",
+          "hauptbankverbindung": true
+        }
+      ]
+    },
+    {
+      "iban": "DE7510050000000000002",
+      "gemeinschaftskonto": false,
+      "antragsteller": [
+        {
+          "id": "21794c8f-ad7c-442f-9bd5-1449951acd82",
+          "hauptbankverbindung": false
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Response
+
+:warning: Die Beispielantworten sind fiktiv und gekürzt, sodass die Konditionen bspw. nicht mit dem Tilgungsplan übereinstimmen.
+
+```json
+{
+  "supportMeldung": null,
+  "angebote": [
+    {
+      "produktanbieter": "BEISPIEL_BANK",
+      "referenznummerProduktanbieter": null,
+      "referenznummerDienstleister": null,
+      "produktbezeichnung": "Modernisierungsdarlehen",
+      "produktart": "MODERNISIERUNGSKREDIT",
+      "angebotsvariantentyp": "Beispielvariante",
+      "gesamtkonditionen": {
+        "effektivzinssatz": 0.0132,
+        "sollzinssatz": 0.0123,
+        "gesamtbetrag": 30000.0,
+        "nettokreditbetrag": 25000.0,
+        "auszahlungsbetrag": 25000.0,
+        "laufzeitInMonaten": 187,
+        "rateProMonat": 150.0,
+        "vertragsbeginn": "2019-10-01"
+      },
+      "kredit": {
+        "effektivzinssatz": 0.0132,
+        "sollzinssatz": 0.0123,
+        "gesamtbetrag": 30000.0,
+        "nettokreditbetrag": 25000.0,
+        "auszahlungsbetrag": 25000.0,
+        "laufzeitInMonaten": 94,
+        "rateProMonat": 60.0,
+        "letzteRate": 60.0,
+        "provisionsbetrag": 300.0,
+        "basisbetragFuerDieProvisionsermittlung": 25000.0,
+        "vorlaufzinsenProTag": 0.0,
+        "versicherung": null
+      },
+      "bausparvertrag": {
+        "tarifname": "Beispieltarif",
+        "bausparsumme": 25000.0,
+        "gesamtlaufzeitInMonaten": 187,
+        "zuteilungsZeitpunkt": "2027-07-31",
+        "provision": 400.0,
+        "basisbetragFuerDieProvisionsermittlung": 25000.0,
+        "jahresentgelt": 15.0,
+        "abschlussgebuehr": 400.0,
+        "sparphase": {
+          "sparbeitragMonatlich": 100.0,
+          "dauerInMonaten": 94,
+          "guthabenBeiZuteilung": 10000.0,
+          "guthabenZinssatz": 0.0123
+        },
+        "darlehensphase": {
+          "darlehenssumme": 15000.0,
+          "rateMonatlich": 170.0,
+          "dauerInMonaten": 93,
+          "sollzinsSatz": 0.0123,
+          "effektivzinsSatz": 0.0132,
+          "letzteRate": 10.0,
+          "tilgungsende": "2035-04-30"
+        }
+      },
+      "status": {
+        "machbarkeitsstatus": "MACHBAR",
+        "angepasst": true
+      },
+      "meldungen": [
+        {
+          "kategorie": "ANPASSUNG",
+          "text": "Der Provisionswunsch wurde angepasst.",
+          "code": null
+        },
+        {
+          "kategorie": "ANPASSUNG",
+          "text": "Die Laufzeit wurde angepasst.",
+          "code": null
+        }
+      ],
+      "unterlagen": [
+        {
+          "code": null,
+          "text": "Unterzeichneter Baufinanzierungsvertrag",
+          "referenz": null
+        },
+        {
+          "code": null,
+          "text": "Unterzeichneter Darlehensantrag",
+          "referenz": null
+        }
+      ],
+      "bonitaetscheck": {
+        "name": "Haushaltsrechnung",
+        "ueberschrift": "Beispielbank",
+        "ueberschuss": 3500.0,
+        "bloecke": [
+          {
+            "zeilen": [
+              {
+                "hervorgehoben": false,
+                "label": "Unselbständiges Nettoeinkommen",
+                "wert": 6000.0
+              }
+            ],
+            "titel": "Einnahmen",
+            "innerBlock": {
+              "zeilen": [
+                {
+                  "hervorgehoben": true,
+                  "label": "Summe Einnahmen",
+                  "wert": 6000.0
+                }
+              ],
+              "hervorgehoben": true
+            }
+          },
+          {
+            "zeilen": [
+              {
+                "hervorgehoben": false,
+                "label": "Lebenshaltungskosten",
+                "wert": 2400.0
+              },
+              {
+                "hervorgehoben": false,
+                "label": "Rate der Finanzierung",
+                "wert": 150.0
+              }
+            ],
+            "titel": "Ausgaben",
+            "innerBlock": {
+              "zeilen": [
+                {
+                  "hervorgehoben": true,
+                  "label": "Summe Ausgaben",
+                  "wert": 2500.0
+                }
+              ],
+              "hervorgehoben": true
+            }
+          },
+          {
+            "zeilen": null,
+            "titel": "Überschuss / Fehlbetrag",
+            "innerBlock": {
+              "zeilen": [
+                {
+                  "hervorgehoben": true,
+                  "label": "Überschuss",
+                  "wert": 3000.0
+                }
+              ],
+              "hervorgehoben": true
+            }
+          }
+        ]
+      },
+      "tilgungsplanBausparvertragMitVorausdarlehen": {
+        "sparphase": {
+          "eintraege": [
+            {
+              "jahr": 2019,
+              "monat": 10,
+              "gesamtrate": 150.0,
+              "vorausdarlehenSollzinsen": -50.0,
+              "vorausdarlehenSaldo": -25000.0,
+              "bausparvertragEinzahlungen": 100.0,
+              "bausparvertragGuthabenzinsen": 0.0,
+              "bausparvertragGebuehren": -400.0,
+              "bausparvertragTilgung": null,
+              "bausparvertragSollzinsen": null,
+              "bausparvertragSaldo": -300.0
+            },
+            {
+              "jahr": 2019,
+              "monat": 11,
+              "gesamtrate": 150.0,
+              "vorausdarlehenSollzinsen": -50.0,
+              "vorausdarlehenSaldo": -25000.0,
+              "bausparvertragEinzahlungen": 100.0,
+              "bausparvertragGuthabenzinsen": 0.0,
+              "bausparvertragGebuehren": 0.0,
+              "bausparvertragTilgung": null,
+              "bausparvertragSollzinsen": null,
+              "bausparvertragSaldo": -150.0
+            },
+            {
+              "jahr": 2027,
+              "monat": null,
+              "gesamtrate": 1000.0,
+              "vorausdarlehenSollzinsen": -450.0,
+              "vorausdarlehenSaldo": null,
+              "bausparvertragEinzahlungen": 700.0,
+              "bausparvertragGuthabenzinsen": 10.0,
+              "bausparvertragGebuehren": -10.0,
+              "bausparvertragTilgung": null,
+              "bausparvertragSollzinsen": null,
+              "bausparvertragSaldo": null
+            }
+          ],
+          "werteBeiPhasenEnde": {
+            "gesamtrate": 15000.0,
+            "vorausdarlehenSollzinsen": -6000.0,
+            "vorausdarlehenSaldo": -25000.0,
+            "bausparvertragEinzahlungen": 10000.0,
+            "bausparvertragGuthabenzinsen": 70.0,
+            "bausparvertragGebuehren": -500.0,
+            "bausparvertragTilgung": null,
+            "bausparvertragSollzinsen": null,
+            "bausparvertragSaldo": 10000.0
+          }
+        },
+        "darlehensphase": {
+          "eintraege": [
+            {
+              "jahr": 2027,
+              "monat": 7,
+              "gesamtrate": 0.0,
+              "vorausdarlehenSollzinsen": null,
+              "vorausdarlehenSaldo": null,
+              "bausparvertragEinzahlungen": null,
+              "bausparvertragGuthabenzinsen": null,
+              "bausparvertragGebuehren": null,
+              "bausparvertragTilgung": 0.0,
+              "bausparvertragSollzinsen": 0.0,
+              "bausparvertragSaldo": -15000.0
+            },
+            {
+              "jahr": 2027,
+              "monat": 8,
+              "gesamtrate": 150.0,
+              "vorausdarlehenSollzinsen": null,
+              "vorausdarlehenSaldo": null,
+              "bausparvertragEinzahlungen": null,
+              "bausparvertragGuthabenzinsen": null,
+              "bausparvertragGebuehren": null,
+              "bausparvertragTilgung": 150.0,
+              "bausparvertragSollzinsen": -30.0,
+              "bausparvertragSaldo": -15000.0
+            },
+            {
+              "jahr": 2035,
+              "monat": null,
+              "gesamtrate": 50.0,
+              "vorausdarlehenSollzinsen": null,
+              "vorausdarlehenSaldo": null,
+              "bausparvertragEinzahlungen": null,
+              "bausparvertragGuthabenzinsen": null,
+              "bausparvertragGebuehren": null,
+              "bausparvertragTilgung": 550.0,
+              "bausparvertragSollzinsen": -2.0,
+              "bausparvertragSaldo": null
+            }
+          ],
+          "werteBeiPhasenEnde": {
+            "gesamtrate": 15000.0,
+            "vorausdarlehenSollzinsen": null,
+            "vorausdarlehenSaldo": null,
+            "bausparvertragEinzahlungen": null,
+            "bausparvertragGuthabenzinsen": null,
+            "bausparvertragGebuehren": null,
+            "bausparvertragTilgung": 15000.0,
+            "bausparvertragSollzinsen": -1500.0,
+            "bausparvertragSaldo": 0.0
+          }
+        }
+      },
+      "maximalerAuszahlungsbetrag": null,
+      "angeforderteA2aKonten": [
+        {
+          "iban": "DE7510050000000000000"
+        },
+        {
+          "iban": "DE7510050000000000001"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/beispiele/annahme-mit-a2a-daten.md
+++ b/beispiele/annahme-mit-a2a-daten.md
@@ -1,0 +1,476 @@
+## Annahme mit vollständigen Angaben (ein Antragsteller)
+
+Die aufgelisteten Beispielanfragen und -antworten dienen zum besseren Verständnis der API. 
+
+Die Beispielantworten sind fiktiv und gekürzt, sodass die Konditionen bspw. nicht mit dem Tilgungsplan übereinstimmen.   
+
+Anmerkung zum Tilgungsplan:
+- i.d.R. wird das erste Jahr monatsweise aufgelistet
+- i.d.R. werden alle weiteren Jahre jeweils zu einem einzelnen Eintrag pro Jahr aggregiert
+- die Beispielantworten enthalten lediglich die ersten beiden und den letzten Eintrag - die Dazwischenliegenden wurden entfernt  
+
+### Request
+
+```json
+{
+  "antragsteller": [
+    {
+      "id": "552a2e18-b407-44ce-8af5-f6334cc64f80",
+      "persoenlicheAngaben": {
+        "anrede": "HERR",
+        "vorname": "Beispiel Vorname",
+        "nachname": "Beispiel Nachname",
+        "geburtsdatum": "1970-01-01",
+        "geburtsort": "Berlin",
+        "staatsangehoerigkeit": "DE",
+        "familienstand": "LEDIG",
+        "anzahlPersonenImHaushalt": 1
+      },
+      "derzeitigeBeschaeftigung": {
+        "beschaeftigungsverhaeltnis": "ANGESTELLT",
+        "befristet": "UNBEFRISTET",
+        "beschaeftigtSeit": "2010-01-01",
+        "beruf": "Angestellter",
+        "branche": "HANDEL",
+        "anschrift": {
+          "strasse": "Beispielstr.",
+          "hausnummer": "43",
+          "postleitzahl": "10179",
+          "ort": "Berlin",
+          "land": "DE"
+        },
+        "arbeitgebername": "Beispiel AG"
+      },
+      "vorherigeBeschaeftigung": {
+        "anschrift": {}
+      },
+      "derzeitigeWohnsituation": {
+        "wohnart": "IM_EIGENEN_HAUS",
+        "wohnhaftSeit": "2000-01-01",
+        "anschrift": {
+          "strasse": "Beispielstr.",
+          "hausnummer": "42",
+          "postleitzahl": "10179",
+          "ort": "Berlin",
+          "land": "DE"
+        }
+      },
+      "kontakt": {
+        "telefonPrivat": "030 123456",
+        "telefonGeschaeftlich": "030 123456",
+        "email": "beispiel@beispiel.de"
+      },
+      "herkunft": {
+        "aufenthaltstitel": {}
+      },
+      "kinder": [],
+      "rentenversicherung": {
+        "anschrift": {}
+      },
+      "bonitaetsangaben": {
+        "ausgaben": {},
+        "einnahmen": {
+          "monatlicheEinnahmen": {
+            "regelmaessigesUnselbstaendigesEinkommen": 3000,
+            "mietUndPachteinnahmen": {}
+          },
+          "jaehrlicheEinnahmen": {
+            "einkommenAusSelbstaendigkeit": {
+              "zuVersteuerndesEinkommen": {},
+              "einkommenssteuer": {},
+              "abschreibungen": {}
+            }
+          }
+        },
+        "vermoegen": {
+          "immobilien": []
+        },
+        "verbindlichkeiten": {
+          "ratenkredite": [],
+          "sonstigeVerbindlichkeiten": [],
+          "leasings": [],
+          "kreditkarten": [],
+          "dispositionskredite": [],
+          "immobiliendarlehen": []
+        }
+      }
+    }
+  ],
+  "gemeinsameAntragstellerangaben": {
+    "bonitaetsangaben": {},
+    "ruecklastschrift": {
+      "ruecklastschriftWithinDays": 90
+    }
+  },
+  "finanzierungswunsch": {
+    "kreditwunsch": {
+      "finanzierungszweck": "MODERNISIERUNG_UND_WOHNEN",
+      "auszahlungsbetrag": 25000.0,
+      "ratenzahlungstermin": "ULTIMO",
+      "laufzeitInMonaten": 92
+    },
+    "versicherungsWunsch": [],
+    "konto": {
+      "kontoinhaberIds": []
+    },
+    "abzuloesendeVerbindlichkeiten": {
+      "ratenkredite": [],
+      "sonstigeVerbindlichkeiten": [],
+      "kreditkarten": [],
+      "dispositionskredite": []
+    },
+    "fahrzeug": {},
+    "modernisierung": {}
+  },
+  "kundenbetreuer": {
+    "partnerId": "ABC12",
+    "firmenname": "Beispiel AG",
+    "vorname": "Beispiel Vorname",
+    "nachname": "Beispiel Nachname",
+    "anschrift": {
+      "strasse": "Beispielstr.",
+      "hausnummer": "42",
+      "postleitzahl": "10179",
+      "ort": "Berlin"
+    },
+    "telefon": "030 123456",
+    "email": "beispiel@beispiel.de",
+    "iban": "DE75201207003100124444",
+    "anrede": "HERR"
+  },
+  "metadaten": {
+    "traceId": "ks-d94c85a",
+    "vorgangsnummer": "AB1234",
+    "antragsnummer": "AB1234/1/1"
+  },
+  "featureToggles": [],
+  "bearbeiter": {
+    "vorname": "Daniel",
+    "nachname": "Teske"
+  },
+  "handelsbeziehung": {
+    "produktanbieter": "BEISPIEL_BANK",
+    "kreditProvisionswunsch": 0.0123,
+    "vertriebsgruppe": "Beispielgruppe"
+  },
+  "angebotsvariantentyp": "Beispielvariante",
+  "beratungsart": "PRAESENZ_GESCHAEFT",
+  "a2aKontenMitUmsaetzen": [
+    {
+      "iban": "DE7510050000000000000",
+      "gemeinschaftskonto": true,
+      "antragsteller": [
+        {
+          "id": "552a2e18-b407-44ce-8af5-f6334cc64f80",
+          "hauptbankverbindung": false
+        },
+        {
+          "id": "21794c8f-ad7c-442f-9bd5-1449951acd82",
+          "hauptbankverbindung": true
+        }
+      ],
+      "umsatzdaten": "base64-encoded-umsatzdaten"
+    },
+    {
+      "iban": "DE7510050000000000001",
+      "gemeinschaftskonto": true,
+      "antragsteller": [
+        {
+          "id": "552a2e18-b407-44ce-8af5-f6334cc64f80",
+          "hauptbankverbindung": true
+        }
+      ],
+      "umsatzdaten": "base64-encoded-umsatzdaten"
+    }
+  ]
+}
+```
+
+### Response
+
+:warning: Die Beispielantworten sind fiktiv und gekürzt, sodass die Konditionen bspw. nicht mit dem Tilgungsplan übereinstimmen.
+
+```json
+{
+  "angebot": {
+    "produktanbieter": "BEISPIEL_BANK",
+    "referenznummerProduktanbieter": null,
+    "referenznummerDienstleister": null,
+    "produktbezeichnung": "Modernisierungsdarlehen",
+    "produktart": "MODERNISIERUNGSKREDIT",
+    "angebotsvariantentyp": "Beispielvariante",
+    "gesamtkonditionen": {
+      "effektivzinssatz": 0.0132,
+      "sollzinssatz": 0.0123,
+      "gesamtbetrag": 33000.0,
+      "nettokreditbetrag": 25000.0,
+      "auszahlungsbetrag": 25000.0,
+      "laufzeitInMonaten": 180,
+      "rateProMonat": 180.0,
+      "vertragsbeginn": "2019-10-01"
+    },
+    "kredit": {
+      "effektivzinssatz": 0.0132,
+      "sollzinssatz": 0.0123,
+      "gesamtbetrag": 33000.0,
+      "nettokreditbetrag": 25000.0,
+      "auszahlungsbetrag": 25000.0,
+      "laufzeitInMonaten": 94,
+      "rateProMonat": 60.0,
+      "letzteRate": 60.0,
+      "provisionsbetrag": 400.0,
+      "basisbetragFuerDieProvisionsermittlung": 25000.0,
+      "vorlaufzinsenProTag": 0.0,
+      "versicherung": null
+    },
+    "bausparvertrag": {
+      "tarifname": "Beispieltarif",
+      "bausparsumme": 25000.0,
+      "gesamtlaufzeitInMonaten": 187,
+      "zuteilungsZeitpunkt": "2027-05-31",
+      "provision": 450.0,
+      "basisbetragFuerDieProvisionsermittlung": 25000.0,
+      "jahresentgelt": 15.0,
+      "abschlussgebuehr": 400.0,
+      "sparphase": {
+        "sparbeitragMonatlich": 100.0,
+        "dauerInMonaten": 94,
+        "guthabenBeiZuteilung": 10000.0,
+        "guthabenZinssatz": 0.0123
+      },
+      "darlehensphase": {
+        "darlehenssumme": 15000.0,
+        "rateMonatlich": 150.0,
+        "dauerInMonaten": 93,
+        "sollzinsSatz": 0.0123,
+        "effektivzinsSatz": 0.0132,
+        "letzteRate": 10.0,
+        "tilgungsende": "2035-02-28"
+      }
+    },
+    "status": {
+      "machbarkeitsstatus": "MACHBAR",
+      "angepasst": true
+    },
+    "meldungen": [
+      {
+        "kategorie": "ANPASSUNG",
+        "text": "Der Provisionswunsch wurde angepasst.",
+        "code": null
+      },
+      {
+        "kategorie": "ANPASSUNG",
+        "text": "Die Laufzeit wurde angepasst.",
+        "code": null
+      }
+    ],
+    "unterlagen": [
+      {
+        "code": null,
+        "text": "Unterzeichneter Baufinanzierungsvertrag",
+        "referenz": null
+      },
+      {
+        "code": null,
+        "text": "Unterzeichneter Darlehensantrag",
+        "referenz": null
+      }
+    ],
+    "bonitaetscheck": {
+      "name": "Haushaltsrechnung",
+      "ueberschrift": "Beispielbank",
+      "ueberschuss": 1500.0,
+      "bloecke": [
+        {
+          "zeilen": [
+            {
+              "hervorgehoben": false,
+              "label": "Unselbständiges Nettoeinkommen",
+              "wert": 3000.0
+            }
+          ],
+          "titel": "Einnahmen",
+          "innerBlock": {
+            "zeilen": [
+              {
+                "hervorgehoben": true,
+                "label": "Summe Einnahmen",
+                "wert": 3000.0
+              }
+            ],
+            "hervorgehoben": true
+          }
+        },
+        {
+          "zeilen": [
+            {
+              "hervorgehoben": false,
+              "label": "Lebenshaltungskosten",
+              "wert": 1200.0
+            },
+            {
+              "hervorgehoben": false,
+              "label": "Rate der Finanzierung",
+              "wert": 150.0
+            }
+          ],
+          "titel": "Ausgaben",
+          "innerBlock": {
+            "zeilen": [
+              {
+                "hervorgehoben": true,
+                "label": "Summe Ausgaben",
+                "wert": 1500.0
+              }
+            ],
+            "hervorgehoben": true
+          }
+        },
+        {
+          "zeilen": null,
+          "titel": "Überschuss / Fehlbetrag",
+          "innerBlock": {
+            "zeilen": [
+              {
+                "hervorgehoben": true,
+                "label": "Überschuss",
+                "wert": 1500.0
+              }
+            ],
+            "hervorgehoben": true
+          }
+        }
+      ]
+    },
+    "tilgungsplanBausparvertragMitVorausdarlehen": {
+      "sparphase": {
+        "eintraege": [
+          {
+            "jahr": 2019,
+            "monat": 10,
+            "gesamtrate": 150.0,
+            "vorausdarlehenSollzinsen": -60.0,
+            "vorausdarlehenSaldo": -25000.0,
+            "bausparvertragEinzahlungen": 100.0,
+            "bausparvertragGuthabenzinsen": 0.0,
+            "bausparvertragGebuehren": -400.0,
+            "bausparvertragTilgung": null,
+            "bausparvertragSollzinsen": null,
+            "bausparvertragSaldo": -250.0
+          },
+          {
+            "jahr": 2019,
+            "monat": 11,
+            "gesamtrate": 150.0,
+            "vorausdarlehenSollzinsen": -60.0,
+            "vorausdarlehenSaldo": -25000.0,
+            "bausparvertragEinzahlungen": 100.0,
+            "bausparvertragGuthabenzinsen": 0.0,
+            "bausparvertragGebuehren": 0.0,
+            "bausparvertragTilgung": null,
+            "bausparvertragSollzinsen": null,
+            "bausparvertragSaldo": -150.0
+          },
+          {
+            "jahr": 2027,
+            "monat": null,
+            "gesamtrate": 1000.0,
+            "vorausdarlehenSollzinsen": -450.9,
+            "vorausdarlehenSaldo": null,
+            "bausparvertragEinzahlungen": 650.0,
+            "bausparvertragGuthabenzinsen": 10.0,
+            "bausparvertragGebuehren": -10.0,
+            "bausparvertragTilgung": null,
+            "bausparvertragSollzinsen": null,
+            "bausparvertragSaldo": null
+          }
+        ],
+        "werteBeiPhasenEnde": {
+          "gesamtrate": 15000.0,
+          "vorausdarlehenSollzinsen": -5000.0,
+          "vorausdarlehenSaldo": -25000.0,
+          "bausparvertragEinzahlungen": 10000.0,
+          "bausparvertragGuthabenzinsen": 70.0,
+          "bausparvertragGebuehren": -500.0,
+          "bausparvertragTilgung": null,
+          "bausparvertragSollzinsen": null,
+          "bausparvertragSaldo": 10000.0
+        }
+      },
+      "darlehensphase": {
+        "eintraege": [
+          {
+            "jahr": 2027,
+            "monat": 7,
+            "gesamtrate": 0.0,
+            "vorausdarlehenSollzinsen": null,
+            "vorausdarlehenSaldo": null,
+            "bausparvertragEinzahlungen": null,
+            "bausparvertragGuthabenzinsen": null,
+            "bausparvertragGebuehren": null,
+            "bausparvertragTilgung": 0.0,
+            "bausparvertragSollzinsen": 0.0,
+            "bausparvertragSaldo": -14000.0
+          },
+          {
+            "jahr": 2027,
+            "monat": 8,
+            "gesamtrate": 150.0,
+            "vorausdarlehenSollzinsen": null,
+            "vorausdarlehenSaldo": null,
+            "bausparvertragEinzahlungen": null,
+            "bausparvertragGuthabenzinsen": null,
+            "bausparvertragGebuehren": null,
+            "bausparvertragTilgung": 150.0,
+            "bausparvertragSollzinsen": -30.0,
+            "bausparvertragSaldo": -15000.0
+          },
+          {
+            "jahr": 2035,
+            "monat": null,
+            "gesamtrate": 500.0,
+            "vorausdarlehenSollzinsen": null,
+            "vorausdarlehenSaldo": null,
+            "bausparvertragEinzahlungen": null,
+            "bausparvertragGuthabenzinsen": null,
+            "bausparvertragGebuehren": null,
+            "bausparvertragTilgung": 500.0,
+            "bausparvertragSollzinsen": -5.0,
+            "bausparvertragSaldo": null
+          }
+        ],
+        "werteBeiPhasenEnde": {
+          "gesamtrate": 16466.44,
+          "vorausdarlehenSollzinsen": null,
+          "vorausdarlehenSaldo": null,
+          "bausparvertragEinzahlungen": null,
+          "bausparvertragGuthabenzinsen": null,
+          "bausparvertragGebuehren": null,
+          "bausparvertragTilgung": 14989.63,
+          "bausparvertragSollzinsen": -1476.81,
+          "bausparvertragSaldo": 0.0
+        }
+      }
+    },
+    "maximalerAuszahlungsbetrag": null
+  },
+  "dokumente": [
+    {
+      "dateiname": "Bausparantrag.pdf",
+      "base64pdf": "(pdf-als-base64)",
+      "sichtbarkeit": {
+        "sichtbarFuerVertrieb": true,
+        "sichtbarFuerProduktanbieter": true
+      }
+    },
+    {
+      "dateiname": "Darlehensvertrag.pdf",
+      "base64pdf": "(pdf-als-base64)",
+      "sichtbarkeit": {
+        "sichtbarFuerVertrieb": true,
+        "sichtbarFuerProduktanbieter": true
+      }
+    }
+  ]
+}
+```

--- a/swagger.yml
+++ b/swagger.yml
@@ -1466,7 +1466,8 @@ definitions:
     properties:
       konten:
         type: array
-        $ref: '#/definitions/angefordertesA2aKonto'
+        items:
+          $ref: '#/definitions/angefordertesA2aKonto'
       format:
         $ref: '#/definitions/a2aKontoFormat'
     required:

--- a/swagger.yml
+++ b/swagger.yml
@@ -92,6 +92,11 @@ definitions:
             type: array
             items:
               $ref: '#/definitions/handelsbeziehung'
+          a2aKonten:
+            description: Liste der verfügbaren A2A-Konten mit zugehörigen AntragstellerIds und Metadaten
+            type: array
+            items:
+              $ref: "#/definitions/a2aKonto"
 
   annahmeRequest:
     allOf:
@@ -107,6 +112,11 @@ definitions:
             type: string
           beratungsart:
             $ref: '#/definitions/beratungsart'
+          a2aKontenWithKontoumsaetze:
+            description: Liste mit Kontoumsatzdaten und zugehörigen AntragstellerIds und Metdaten
+            type: array
+            items:
+              $ref: "#/definitions/a2aKontoMitUmsaetzen"
         required:
           - angebotsvariantentyp
           - handelsbeziehung
@@ -118,6 +128,46 @@ definitions:
       - PRAESENZ_GESCHAEFT
       - FERN_ABSATZ_GESCHAEFT
       - AUSSER_GESCHAEFTSRAUM_VERTRAG
+
+  a2aKonto:
+    type: object
+    properties:
+      id:
+        type: string
+      iban:
+        type: string
+      gemeinschaftskonto:
+        type: boolean
+      antragsteller:
+        type: array
+        items:
+          $ref: "#/definitions/a2aKontoAntragsteller"
+    required:
+      - id
+      - iban
+
+  a2aKontoMitUmsaetzen:
+    allOf:
+      - $ref: '#/definitions/a2aKonto'
+      - type: object
+        properties:
+          umsatzdaten:
+            type: string
+            description: Base64 kodierte Kontoumsatzdaten
+            format: byte
+        required:
+          - umsatzdaten
+
+  a2aKontoAntragsteller:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Referenziert die ID des Antragstellers.
+      hauptbankverbindung:
+        type: boolean
+    required:
+      - id
 
   ###
   ### Meta
@@ -1030,6 +1080,9 @@ definitions:
       alternative:
         description: Pflichtfeld wenn sich das Angebot um ein Downsell-Angebot handelt. Ein Downsell liegt vor, wenn die gwwünschte Laufzeit verlängert und oder der gewünschte Kreditbetrag verringert wird, um eine nagtive Haushaltsrechnung auszugleichen. In diesem Falle ist zusätzlich mindestens eine Anpassungsmeldung zu liefern.
         $ref: '#/definitions/angebotAlternative'
+      angeforderteA2aKonten:
+        description: Liste der ID's der A2A-Konten, deren Umsatzdaten der Produktanbieter verwenden möchte. Die Lieferung der A2A-Daten erfolgt nur nach Absprache mit der Europace Ratenkredit GmbH.
+        $ref: '#/definitions/angeforderteA2aKonten'
     required:
       - produktanbieter
       - produktbezeichnung
@@ -1407,6 +1460,34 @@ definitions:
         $ref: '#/definitions/angebotAlternativeTyp'
     required:
       - typ
+
+  angeforderteA2aKonten:
+    type: object
+    properties:
+      konten:
+        type: array
+        $ref: '#/definitions/angefordertesA2aKonto'
+      format:
+        $ref: '#/definitions/a2aKontoFormat'
+    required:
+      - konten
+      - format
+
+  angefordertesA2aKonto:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Referenziert a2aKonto.id
+    required:
+      - id
+
+  a2aKontoFormat:
+    type: string
+    description: Gibt an ob Kontoumsätze kategorisiert oder im Rohformat geliefert werden sollen.
+    enum:
+      - RAW
+      - CATEGORIZED
 
   angebotAlternativeTyp:
     type: string

--- a/swagger.yml
+++ b/swagger.yml
@@ -137,7 +137,7 @@ definitions:
         description: IBAN des A2A-Kontos
       gemeinschaftskonto:
         type: boolean
-        description: Ist true wenn es sich beim A2A-Konto um ein Gemeinschaftskonto handelt, andernfalls false
+        description: Ist true, wenn es sich beim A2A-Konto um ein Gemeinschaftskonto handelt, andernfalls false
       antragsteller:
         type: array
         description: Referenziert die Antragsteller aus dem Request, welche Kontoinhaber des A2A-Kontos sind

--- a/swagger.yml
+++ b/swagger.yml
@@ -112,7 +112,7 @@ definitions:
             type: string
           beratungsart:
             $ref: '#/definitions/beratungsart'
-          a2aKontenWithKontoumsaetze:
+          a2aKontenMitUmsaetzen:
             description: Liste mit Kontoumsatzdaten und zugehörigen AntragstellerIds und Metdaten
             type: array
             items:

--- a/swagger.yml
+++ b/swagger.yml
@@ -134,12 +134,16 @@ definitions:
     properties:
       id:
         type: string
+        description: ID dient zur Referenzierung des A2A-Kontos in der Repsonse
       iban:
         type: string
+        description: IBAN des A2A-Kontos
       gemeinschaftskonto:
         type: boolean
+        description: Ist true wenn es sich beim A2A-Konto um ein Gemeinschaftskonto handelt, andernfalls false
       antragsteller:
         type: array
+        description: Referenziert die Antragsteller aus dem Request welche Kontoinhaber des A2A-Kontos sind
         items:
           $ref: "#/definitions/a2aKontoAntragsteller"
     required:

--- a/swagger.yml
+++ b/swagger.yml
@@ -132,9 +132,6 @@ definitions:
   a2aKonto:
     type: object
     properties:
-      id:
-        type: string
-        description: ID dient zur Referenzierung des A2A-Kontos in der Repsonse
       iban:
         type: string
         description: IBAN des A2A-Kontos
@@ -147,7 +144,6 @@ definitions:
         items:
           $ref: "#/definitions/a2aKontoAntragsteller"
     required:
-      - id
       - iban
 
   a2aKontoMitUmsaetzen:
@@ -1472,8 +1468,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/angefordertesA2aKonto'
-      format:
-        $ref: '#/definitions/a2aKontoFormat'
     required:
       - konten
       - format
@@ -1481,18 +1475,11 @@ definitions:
   angefordertesA2aKonto:
     type: object
     properties:
-      id:
+      iban:
         type: string
-        description: Referenziert a2aKonto.id
+        description: Referenziert a2aKonto.iban
     required:
-      - id
-
-  a2aKontoFormat:
-    type: string
-    description: Gibt an ob Kontoumsätze kategorisiert oder im Rohformat geliefert werden sollen.
-    enum:
-      - RAW
-      - CATEGORIZED
+      - iban
 
   angebotAlternativeTyp:
     type: string

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 11.2.1
+  version: 11.3.0
   title: MarketEngine-API für Bausparkassen
 basePath: /v1
 schemes:

--- a/swagger.yml
+++ b/swagger.yml
@@ -1082,7 +1082,10 @@ definitions:
         $ref: '#/definitions/angebotAlternative'
       angeforderteA2aKonten:
         description: Liste der ID's der A2A-Konten, deren Umsatzdaten der Produktanbieter verwenden möchte. Die Lieferung der A2A-Daten erfolgt nur nach Absprache mit der Europace Ratenkredit GmbH.
-        $ref: '#/definitions/angeforderteA2aKonten'
+        type: array
+        items:
+          $ref: '#/definitions/angefordertesA2aKonto'
+
     required:
       - produktanbieter
       - produktbezeichnung
@@ -1460,17 +1463,6 @@ definitions:
         $ref: '#/definitions/angebotAlternativeTyp'
     required:
       - typ
-
-  angeforderteA2aKonten:
-    type: object
-    properties:
-      konten:
-        type: array
-        items:
-          $ref: '#/definitions/angefordertesA2aKonto'
-    required:
-      - konten
-      - format
 
   angefordertesA2aKonto:
     type: object

--- a/swagger.yml
+++ b/swagger.yml
@@ -140,7 +140,7 @@ definitions:
         description: Ist true wenn es sich beim A2A-Konto um ein Gemeinschaftskonto handelt, andernfalls false
       antragsteller:
         type: array
-        description: Referenziert die Antragsteller aus dem Request welche Kontoinhaber des A2A-Kontos sind
+        description: Referenziert die Antragsteller aus dem Request, welche Kontoinhaber des A2A-Kontos sind
         items:
           $ref: "#/definitions/a2aKontoAntragsteller"
     required:
@@ -166,6 +166,7 @@ definitions:
         description: Referenziert die ID des Antragstellers.
       hauptbankverbindung:
         type: boolean
+        description: Beschreibt, ob es sich um das Hauptkonto des Antragstellers mit Gehaltseingängen, Miete, etc. handelt.
     required:
       - id
 
@@ -1081,7 +1082,7 @@ definitions:
         description: Pflichtfeld wenn sich das Angebot um ein Downsell-Angebot handelt. Ein Downsell liegt vor, wenn die gwwünschte Laufzeit verlängert und oder der gewünschte Kreditbetrag verringert wird, um eine nagtive Haushaltsrechnung auszugleichen. In diesem Falle ist zusätzlich mindestens eine Anpassungsmeldung zu liefern.
         $ref: '#/definitions/angebotAlternative'
       angeforderteA2aKonten:
-        description: Liste der ID's der A2A-Konten, deren Umsatzdaten der Produktanbieter verwenden möchte. Die Lieferung der A2A-Daten erfolgt nur nach Absprache mit der Europace Ratenkredit GmbH.
+        description: Liste der IDs der A2A-Konten, deren Umsatzdaten der Produktanbieter verwenden möchte. Die Lieferung der A2A-Daten erfolgt nur nach Absprache mit der Europace Ratenkredit GmbH.
         type: array
         items:
           $ref: '#/definitions/angefordertesA2aKonto'


### PR DESCRIPTION
Erweiterung der API die einerseits die Selektion der an den Produktanbieter zu liefernden A2A Daten ermöglicht und andererseits die Lieferung eben derer. 
Die KontocheckOption ist nicht erforderlich, da der Produktanbieter selber entscheidet ob er entsprechende Vorbehaltsmeldungen erzeugt. Wir liefern also immer wenn A2A-Konten angefordert werden. 
Die BSK ME wird zudem prüfen ob der Produktanbieter grds. das Recht hat A2A Daten im entsprechenden Format zu beziehen.

Enthält folgende Anpassungen:

**Ermittlung-Request**
Neuer Knoten: `a2aKonten` als Liste von Objekten mit den Attributen:
- iban
- gemeisnchaftskonto
- zugeordnete antragsteller inkl. hauptbankverbindungsflag

**Annahme-Request**
Neuer Knoten: `a2aKontenWithKontoumsaetze` als Liste von Objekten analog Ermittlung-Request mit zusätzlichen base64 Umsatzdaten

**Response**
Neuer Knoten: `angeforderteA2aKonten` als Liste von Objekten mit den Attributen:
- Liste der IBAN's der A2A-Konten dessen Umsatzdaten der Produktanbieter erhalten möchte
- gewünschtes Format der Daten

https://europace-ratenkredit.atlassian.net/browse/KITT-4458